### PR TITLE
feature: update room and projects progress when a task is done

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,6 +17,7 @@ const config = {
     "eslint-disable @typescript-eslint/no-unsafe-assignment": "off",
     "eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain":
       "off",
+    "eslint-disable @typescript-eslint/no-misused-promises": "off",
     "@typescript-eslint/consistent-type-imports": [
       "warn",
       {

--- a/prisma/migrations/20240825175703_/migration.sql
+++ b/prisma/migrations/20240825175703_/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `areaId` on the `Task` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Task" DROP COLUMN "areaId",
+ADD COLUMN     "progressUpdate" BOOLEAN;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,9 +43,11 @@ model Task {
     project         Project     @relation(fields: [projectId], references: [id], onDelete: Cascade)
     projectId       String
     rooms           Room[]      
-    areaId          String?
     status          Status @default(todo)
     dueDate         DateTime @default(now())
+    // This field is to identify whether we stop recursion in the db custom update method
+    // TODO: Remove it once Prisma introduces custom arguments to update methods
+    progressUpdate  Boolean? 
 }   
 
 model Room {

--- a/src/app/organization/[organizationId]/projects/page.tsx
+++ b/src/app/organization/[organizationId]/projects/page.tsx
@@ -227,7 +227,7 @@ const OrganizationIdPage = () => {
       id: project.id,
       title: project.name,
       status: project.status,
-      progress: 90,
+      progress: project.progress,
       info: {
         icon: <FaUsers />,
         quantity: project.users ? project.users.length : 0,

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1,12 +1,92 @@
-import { PrismaClient } from "@prisma/client";
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import { Prisma, PrismaClient, type Task } from "@prisma/client";
 
 import { env } from "$/src/env";
 
-const createPrismaClient = () =>
-  new PrismaClient({
+const createPrismaClient = () => {
+  const prisma = new PrismaClient({
     log:
       env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
+  }).$extends({
+    query: {
+      task: {
+        async update({ model, operation, args, query }) {
+          if (args.data.progressUpdate === false) {
+            return query(args);
+          }
+          const result = await prisma.$transaction(async (tx) => {
+            // 1. Update the task
+            args.data.progressUpdate = false;
+            const updateResult = await tx.task.update(args);
+
+            // 2. Update project and rooms with this task
+            await progressUpdate(tx as never, "project", updateResult);
+            await progressUpdate(tx as never, "room", updateResult);
+
+            return updateResult;
+          });
+
+          return new Promise<Task>((resolve) => {
+            resolve(result);
+          });
+        },
+      },
+    },
   });
+
+  /**
+   * Updates the progress
+   * @param tx
+   * @param task
+   * @returns
+   */
+  const progressUpdate = async (
+    tx: typeof prisma,
+    modelType: "project" | "room",
+    task: Task,
+  ) => {
+    const findArgs = {
+      where: { tasks: { some: { id: task.id } } },
+    };
+
+    const models =
+      modelType === "project"
+        ? await tx.project.findMany(findArgs)
+        : await tx.room.findMany(findArgs);
+
+    for (const model of models) {
+      const tasks = await tx.task.findMany({
+        where: { projectId: model?.id },
+      });
+
+      if (tasks.length === 0) {
+        return;
+      }
+
+      let doneCount = 0;
+      tasks.map((task) => {
+        if (task.status === "done" || task.status === "approved") doneCount++;
+      });
+
+      const progressPercentage = (doneCount / tasks.length) * 100;
+
+      const updateArgs = {
+        where: {
+          id: model?.id,
+        },
+        data: {
+          progress: progressPercentage,
+        },
+      };
+
+      modelType === "project"
+        ? await tx.project.update(updateArgs)
+        : await tx.room.update(updateArgs);
+    }
+  };
+
+  return prisma;
+};
 
 const globalForPrisma = globalThis as unknown as {
   prisma: ReturnType<typeof createPrismaClient> | undefined;

--- a/src/tests/tasks.test.ts
+++ b/src/tests/tasks.test.ts
@@ -38,4 +38,41 @@ describe("tasks", () => {
 
     expect(taskData.name).toEqual("Paint");
   });
+
+  test("update a task", async () => {
+    const ctx = await createTestContext(true);
+    const caller = createCaller(ctx);
+
+    let createTaskResponse = await caller.tasks.createTask({
+      name: "Paint",
+      description: "Paint all the walls of the house",
+      dueDate: new Date(),
+      projectId: projectData.id,
+    });
+    let taskData = createTaskResponse.data;
+    expect(taskData.name).toEqual("Paint");
+
+    createTaskResponse = await caller.tasks.createTask({
+      name: "Demolish",
+      description: "Demolish walls",
+      dueDate: new Date(),
+      projectId: projectData.id,
+    });
+    taskData = createTaskResponse.data;
+    expect(taskData.name).toEqual("Demolish");
+
+    // Update the task to done - We expect the project progress to update to 50% complete
+    const updateTaskResponse = await caller.tasks.updateTask({
+      id: taskData.id,
+      status: "done",
+    });
+    taskData = updateTaskResponse.data;
+
+    expect(taskData.status).toEqual("done");
+
+    const projectResponse = await caller.projects.getOne({
+      id: projectData.id,
+    });
+    expect(projectResponse?.progress).toEqual(50);
+  });
 });

--- a/src/utils/tests/tests.ts
+++ b/src/utils/tests/tests.ts
@@ -9,6 +9,9 @@ import { faker } from "@faker-js/faker";
 
 export async function cleanUpDatabase(db: PrismaClient) {
   await db.user.deleteMany({});
+  await db.task.deleteMany({});
+  await db.room.deleteMany({});
+  await db.project.deleteMany({});
 }
 
 /**


### PR DESCRIPTION
Update project and room progress when task is done
- Used the prisma client extensions to update progress
- Used prisma transactions to update the task first and then the rooms and project atomically